### PR TITLE
Faster access to Fetch modes

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,10 +1,20 @@
 [
     {
-        "caption": "Fetch",
-        "command": "fetch"
+        "caption": "Fetch: File",
+        "command": "fetch",
+        "args": {
+            "type": "single"
+        }
     },
     {
-        "caption": "Fetch: Manage remote files",
+        "caption": "Fetch: Package",
+        "command": "fetch",
+        "args": {
+            "type": "package"
+        }
+    },
+    {
+        "caption": "Fetch: Manage",
         "command": "open_file", "args":
         {
             "file": "${packages}/User/Fetch.sublime-settings"

--- a/Fetch.py
+++ b/Fetch.py
@@ -35,14 +35,19 @@ class FetchCommand(sublime_plugin.WindowCommand):
             s.set('files', self.filesPlaceholder)
         sublime.save_settings('Fetch.sublime-settings')
 
-    def run(self):
+    def run(self, *args, **kwargs):
+        _type = kwargs.get('type', None)
         self.s = sublime.load_settings('Fetch.sublime-settings')
         self.fileList = []
         self.packageList = []
 
-        options = ['Single file', 'Package file']
-
-        self.window.show_quick_panel(options, self.callback)
+        if _type == 'single':
+            self.list_files()
+        elif _type == 'package':
+            self.list_packages()
+        else:
+            options = ['Single file', 'Package file']
+            self.window.show_quick_panel(options, self.callback)
 
     def callback(self, index):
         if not self.window.views():


### PR DESCRIPTION
Thanks for making fetch.

One hurdle I've found with using fetch is the extra menu choices required to get to the action for fetch file or fetch package.

I made a change to remove the second level "Single file" or "Package file" menu and instead expose those commands at the top level so you can go straight from opening the command palette to the action you want.

The three actions exposed are:

```
Fetch: File
Fetch: Package
Fetch: Manage
```

The nice part is, with Sublime Text's great fuzzy searching, you can now get straight to the fetch file menu option by opening the command palette and typing `ff`, or jump to fetch package by typing `fp`, which makes it very fast.

Thought I'd share because you may want to integrate this into the main plugin.

Cheers,

Ian
