### PR TITLE
Fix string concatenation in fetch_get command

### DIFF
--- a/Fetch.py
+++ b/Fetch.py
@@ -178,15 +178,15 @@ class FetchGetCommand(sublime_plugin.TextCommand):
 
         self.view.erase_status('fetch')
         if status and self.option == 'package':
-            sublime.status_message('The package from %s was successfully' +
-                                   ' downloaded and extracted' % (self.url))
+            sublime.status_message(('The package from %s was successfully' +
+                                   ' downloaded and extracted') % self.url)
 
         elif status and self.option == 'txt':
             for region in self.view.sel():
                 self.view.replace(edit, region, txt)
 
-            sublime.status_message('The file was successfully downloaded' +
-                                   ' from %s' % (self.url))
+            sublime.status_message(('The file was successfully downloaded' +
+                                   ' from %s') % self.url)
 
 
 class FetchDownload(threading.Thread):


### PR DESCRIPTION
- Some of the status_messages weren't displayed because of syntax error in
  handle_threads() function in FetchGetCommand class.

Fixes this error message:

```
Traceback (most recent call last):
  File ".\Fetch.py", line 176, in <lambda>
    File ".\Fetch.py", line 182, in handle_threads
    TypeError: not all arguments converted during string formatting
```
